### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     hostname: sync-gateway
     container_name: sync-gateway
     depends_on:
-      - couchbase
+      - couchbase-server
     working_dir: /docker-syncgateway
     stdin_open: true
     tty: true      


### PR DESCRIPTION
The original name of service is couchbase-server. In existing yml, Sync gateway depends on "couchbase" service. Docker wont start without this fix