### PR TITLE
fix 'depends_on' typos

### DIFF
--- a/couchbase-arm64/docker-compose.yml
+++ b/couchbase-arm64/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     hostname: sync-gateway
     container_name: sync-gateway
     depends_on:
-      - couchbase
+      - couchbase-server
     working_dir: /docker-syncgateway
     stdin_open: true
     tty: true      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     hostname: sync-gateway
     container_name: sync-gateway
     depends_on:
-      - couchbase
+      - couchbase-server
     working_dir: /docker-syncgateway
     stdin_open: true
     tty: true      


### PR DESCRIPTION
Fixed typos in 'depends_on' values of docker-compose.yml files